### PR TITLE
Added downcase for in line 735

### DIFF
--- a/grammars/language-ck2.cson
+++ b/grammars/language-ck2.cson
@@ -732,7 +732,7 @@ repository:
             name: 'storage.type.class.codetag'
             captures:
               1: name: 'punctuation.definition.codetag.at-sign'
-              2: name: 'entity.name.codetag.$2'
+              2: name: 'entity.name.codetag.${2:/downcase}'
               3: name: 'entity.type.codetag.todo'
               4: name: 'entity.type.codetag.fixme'
               5: name: 'entity.type.codetag.bug'

--- a/spec/language-crusader-kings--i-i-spec.js
+++ b/spec/language-crusader-kings--i-i-spec.js
@@ -44,14 +44,14 @@ describe("CK2 grammar", function() {
     let tokens = grammar.tokenizeLine("# TODO").tokens;
     expect(tokens[0]).toEqual({value: "#", scopes:[root, "comment.line.number-sign.ck2", "meta.comment.line.number-sign.ck2", "punctuation.definition.comment.number-sign.ck2"]});
     expect(tokens[1]).toEqual({value: " ", scopes:[root, 'comment.line.number-sign.ck2', "meta.comment.line.number-sign.ck2"]});
-    expect(tokens[2]).toEqual({value: "TODO", scopes:[root, "comment.line.number-sign.ck2", "meta.comment.line.number-sign.ck2", "storage.type.class.codetag", "entity.name.codetag.TODO", "entity.type.codetag.todo"]});
+    expect(tokens[2]).toEqual({value: "TODO", scopes:[root, "comment.line.number-sign.ck2", "meta.comment.line.number-sign.ck2", "storage.type.class.codetag", "entity.name.codetag.todo", "entity.type.codetag.todo"]});
   });
 
   it("tokenizes codetag synonyms in comments", () => {
     let tokens = grammar.tokenizeLine("# DONE").tokens;
     expect(tokens[0]).toEqual({value: "#", scopes:[root, "comment.line.number-sign.ck2", "meta.comment.line.number-sign.ck2", "punctuation.definition.comment.number-sign.ck2"]});
     expect(tokens[1]).toEqual({value: " ", scopes:[root, 'comment.line.number-sign.ck2', "meta.comment.line.number-sign.ck2"]});
-    expect(tokens[2]).toEqual({value: "DONE", scopes:[root, "comment.line.number-sign.ck2", "meta.comment.line.number-sign.ck2", "storage.type.class.codetag", "entity.name.codetag.DONE", "entity.type.codetag.todo"]});
+    expect(tokens[2]).toEqual({value: "DONE", scopes:[root, "comment.line.number-sign.ck2", "meta.comment.line.number-sign.ck2", "storage.type.class.codetag", "entity.name.codetag.done", "entity.type.codetag.todo"]});
   });
 
   it("tokenizes double quoted strings", () => {


### PR DESCRIPTION
Added the downcase command so the name returns as downcase

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Added downcase in line 735 so the name returns as lower case

### Benefits

The entity name is now downcase

### Possible Drawbacks

It doesn't work. But it should

### Applicable Issues

<!-- Enter any applicable Issues here -->
